### PR TITLE
Correct arthor name for ou24a

### DIFF
--- a/_posts/2024-04-18-ou24a.md
+++ b/_posts/2024-04-18-ou24a.md
@@ -25,14 +25,14 @@ lastpage: 1584
 page: 1576-1584
 order: 1576
 cycles: false
-bibtex_author: Ou, Tingting and Cummings, Rachel and Avella, Marco
+bibtex_author: Ou, Tingting and Cummings, Rachel and Avella Medina, Marco
 author:
 - given: Tingting
   family: Ou
 - given: Rachel
   family: Cummings
 - given: Marco
-  family: Avella
+  family: Avella Medina
 date: 2024-04-18
 address:
 container-title: Proceedings of The 27th International Conference on Artificial Intelligence


### PR DESCRIPTION
Hi there, we'd like to fix one arthor's name for submission id: ou24a. The name that shows up now is "Marco Avella" while this should be "Marco Avella Medina" (Avella Medina is his last name). Could you please fix this so that the article can be correctly identified for him on Google scholar? Thanks!