### PR TITLE
Update 2024-04-18-buch24a.md

### DIFF
--- a/_posts/2024-04-18-buch24a.md
+++ b/_posts/2024-04-18-buch24a.md
@@ -1,6 +1,6 @@
 ---
 title: Simple and scalable algorithms for cluster-aware precision medicine
-software: https://github.com/CARVE-AI
+software: https://github.com/grosenicklab/CARVE-AI
 abstract: AI-enabled precision medicine promises a transformational improvement in
   healthcare outcomes. However, training on biomedical data presents significant challenges
   as they are often high dimensional, clustered, and of limited sample size. To overcome


### PR DESCRIPTION
The link to the software is incorrect and should instead be to my lab github as corrected here. - Logan Grosenick (corresponding senior author).